### PR TITLE
Project migrated to be complient with dotnet (core) build infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ local.properties
 .classpath
 .settings/
 .loadpath
+.vs
+PublishedPackages
 
 # External tool builders
 .externalToolBuilders/

--- a/ConsoleAppLauncher.Tests/ConsoleAppLauncher.Tests.csproj
+++ b/ConsoleAppLauncher.Tests/ConsoleAppLauncher.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.13.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.1\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,6 +15,8 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,8 +37,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.Runners.2.6.2\tools\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.13.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.1\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -60,7 +63,16 @@
       <Name>DummyConsoleApplication</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.13.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.1\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ConsoleAppLauncher.Tests/packages.config
+++ b/ConsoleAppLauncher.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.13.1" targetFramework="net40" />
+</packages>

--- a/ConsoleAppLauncher.sln
+++ b/ConsoleAppLauncher.sln
@@ -1,12 +1,14 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleAppLauncher", "ConsoleAppLauncher\ConsoleAppLauncher.csproj", "{92D1E382-4A58-4458-9DFF-43E6C504FA0F}"
-EndProject
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleAppLauncher.Tests", "ConsoleAppLauncher.Tests\ConsoleAppLauncher.Tests.csproj", "{2C4C68E7-CAFF-45FF-81E0-998724E63E78}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1DFE3034-7ABE-4AD1-ACFA-AEC9484A84F0}"
 	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
 		build.bat = build.bat
 		build_release.bat = build_release.bat
 		ConsoleAppLauncher\ConsoleAppLauncher.nuspec = ConsoleAppLauncher\ConsoleAppLauncher.nuspec
@@ -28,10 +30,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{93B03F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleAppLauncher.Samples", "ConsoleAppLauncher.Samples\ConsoleAppLauncher.Samples.csproj", "{E752D3D4-9A35-404F-9A03-308115D93A11}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleAppLauncher", "ConsoleAppLauncher\ConsoleAppLauncher.csproj", "{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}"
+EndProject
 Global
-	GlobalSection(TestCaseManagementSettings) = postSolution
-		CategoryFile = ConsoleAppLauncher.vsmdi
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms
@@ -41,16 +42,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{92D1E382-4A58-4458-9DFF-43E6C504FA0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{92D1E382-4A58-4458-9DFF-43E6C504FA0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{92D1E382-4A58-4458-9DFF-43E6C504FA0F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{92D1E382-4A58-4458-9DFF-43E6C504FA0F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{92D1E382-4A58-4458-9DFF-43E6C504FA0F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{92D1E382-4A58-4458-9DFF-43E6C504FA0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{92D1E382-4A58-4458-9DFF-43E6C504FA0F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{92D1E382-4A58-4458-9DFF-43E6C504FA0F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{92D1E382-4A58-4458-9DFF-43E6C504FA0F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{92D1E382-4A58-4458-9DFF-43E6C504FA0F}.Release|x86.ActiveCfg = Release|Any CPU
 		{2C4C68E7-CAFF-45FF-81E0-998724E63E78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2C4C68E7-CAFF-45FF-81E0-998724E63E78}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2C4C68E7-CAFF-45FF-81E0-998724E63E78}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -81,8 +72,26 @@ Global
 		{E752D3D4-9A35-404F-9A03-308115D93A11}.Release|Mixed Platforms.Build.0 = Release|x86
 		{E752D3D4-9A35-404F-9A03-308115D93A11}.Release|x86.ActiveCfg = Release|x86
 		{E752D3D4-9A35-404F-9A03-308115D93A11}.Release|x86.Build.0 = Release|x86
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Debug|x86.Build.0 = Debug|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Release|x86.ActiveCfg = Release|Any CPU
+		{5E94F4C6-DB44-423A-A4CC-2C6D9F3684A1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1F618BE7-9E06-4B2F-AAEF-619779F0C8EF}
+	EndGlobalSection
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = ConsoleAppLauncher.vsmdi
 	EndGlobalSection
 EndGlobal

--- a/ConsoleAppLauncher/ConsoleAppLauncher.csproj
+++ b/ConsoleAppLauncher/ConsoleAppLauncher.csproj
@@ -1,53 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{92D1E382-4A58-4458-9DFF-43E6C504FA0F}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SlavaGu.ConsoleAppLauncher</RootNamespace>
-    <AssemblyName>ConsoleAppLauncher</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFrameworks>net4;net45;net5;netcoreapp3.1;netstandard21</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Deterministic>False</Deterministic>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ConsoleApp.cs" />
-    <Compile Include="ConsoleOutputEventArgs.cs" />
-    <Compile Include="IConsoleApp.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Win32.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/build.bat
+++ b/build.bat
@@ -1,14 +1,20 @@
 @echo off
 pushd %~dp0
-if "%WindowsSdkDir%" == "" call "%VS100COMNTOOLS%\vsvars32.bat"
+rem if "%WindowsSdkDir%" == "" call "%VS100COMNTOOLS%\vsvars32.bat"
 
 if "%BUILD_CONFIG%" == "" set BUILD_CONFIG=Debug
 
-echo Building %BUILD_CONFIG%...
-msbuild.exe ConsoleAppLauncher.sln /t:Rebuild /p:Configuration=%BUILD_CONFIG%
+
+rem msbuild.exe ConsoleAppLauncher.sln /t:Rebuild /p:Configuration=%BUILD_CONFIG%
 
 echo Running tests...
-packages\NUnit.Runners.2.6.2\tools\nunit-console.exe "ConsoleAppLauncher.Tests\bin\%BUILD_CONFIG%\ConsoleAppLauncher.Tests.dll" /framework=net-4.0 /labels
+dotnet test -c %BUILD_CONFIG% ConsoleAppLauncher.Tests/ConsoleAppLauncher.Tests.csproj
+
+echo Building %BUILD_CONFIG%...
+dotnet build -c %BUILD_CONFIG% ConsoleAppLauncher/ConsoleAppLauncher.csproj
+
+
+rem packages\NUnit.Runners.2.6.2\tools\nunit-console.exe "ConsoleAppLauncher.Tests\bin\%BUILD_CONFIG%\ConsoleAppLauncher.Tests.dll" /framework=net-4.0 /labels
 
 echo Done.
 popd

--- a/nuget_create.bat
+++ b/nuget_create.bat
@@ -2,10 +2,11 @@
 pushd %~dp0
 
 set BUILD_CONFIG=Release
-call build.bat
+rem call build.bat
 
 echo Creating NuGet package...
-.nuget\NuGet.exe pack ConsoleAppLauncher\ConsoleAppLauncher.csproj -OutputDirectory PublishedPackages -Prop Configuration=%BUILD_CONFIG% -Symbols -Verbosity detailed
+rem .nuget\NuGet.exe pack ConsoleAppLauncher\ConsoleAppLauncher.csproj -OutputDirectory PublishedPackages -Prop Configuration=%BUILD_CONFIG% -Symbols -Verbosity detailed
+dotnet pack -c %BUILD_CONFIG% ConsoleAppLauncher/ConsoleAppLauncher.csproj -o PublishedPackages
 
 echo Done.
 popd


### PR DESCRIPTION
### Dotnet (core) support added
Main point of this change was to add support for modern "dotnet" platform to a package.

#### Generic list of changes

1.  CsProj file format migrated to a new format
2.  Multiple framework targets added: _net4;net45;net5;netcoreapp3.1;netstandard21_
3.  Build scripts updated to use "dotnet" toolset
4.  Test project is using own package dependency now
5.  Solution file is now of format VS 2019
6. Git ignore updated to exclude packed nuget packages and vs temp directory