### PR TITLE
Restore unit test functionality from Visual Studio

### DIFF
--- a/ConsoleAppLauncher.Tests/ConsoleAppLauncher.Tests.csproj
+++ b/ConsoleAppLauncher.Tests/ConsoleAppLauncher.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\NUnit.3.13.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.1\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -72,6 +73,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NUnit.3.13.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ConsoleAppLauncher.Tests/ConsoleAppTest.cs
+++ b/ConsoleAppLauncher.Tests/ConsoleAppTest.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using NUnit.Framework;
 using SlavaGu.ConsoleAppLauncher;
@@ -14,7 +16,8 @@ namespace ConsoleAppLauncher.Tests
         private static IConsoleApp GetDummyApp(string outputLine, int repeat, int delay, bool unstoppable, string prompt = null)
         {
             var cmdLine = string.Format("-output=\"{0}\" -repeat={1} -delay={2} -unstoppable={3} -prompt=\"{4}\"", outputLine, repeat, delay, unstoppable, prompt);
-            return new ConsoleApp("DummyConsoleApplication.exe", cmdLine);
+            var currentDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            return new ConsoleApp(Path.Combine(currentDirectory, "DummyConsoleApplication.exe"), cmdLine);
         }
 
         [Test]

--- a/ConsoleAppLauncher.Tests/packages.config
+++ b/ConsoleAppLauncher.Tests/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.13.1" targetFramework="net40" />
+  <package id="NUnit.ConsoleRunner" version="3.12.0" targetFramework="net40" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net40" />
 </packages>

--- a/build.bat
+++ b/build.bat
@@ -7,14 +7,11 @@ if "%BUILD_CONFIG%" == "" set BUILD_CONFIG=Debug
 
 rem msbuild.exe ConsoleAppLauncher.sln /t:Rebuild /p:Configuration=%BUILD_CONFIG%
 
-echo Running tests...
-dotnet test -c %BUILD_CONFIG% ConsoleAppLauncher.Tests/ConsoleAppLauncher.Tests.csproj
-
 echo Building %BUILD_CONFIG%...
 dotnet build -c %BUILD_CONFIG% ConsoleAppLauncher/ConsoleAppLauncher.csproj
 
-
-rem packages\NUnit.Runners.2.6.2\tools\nunit-console.exe "ConsoleAppLauncher.Tests\bin\%BUILD_CONFIG%\ConsoleAppLauncher.Tests.dll" /framework=net-4.0 /labels
+echo Running tests...
+packages\NUnit.ConsoleRunner.3.12.0\tools\nunit3-console.exe "ConsoleAppLauncher.Tests\bin\%BUILD_CONFIG%\ConsoleAppLauncher.Tests.dll" /framework=net-4.0
 
 echo Done.
 popd


### PR DESCRIPTION
### Unit test fix

#### Changes:

1.  Added proper test adapter to make VS be able to run tests
2.  Restored original way of testing from CMD using nuint console

P.S. Previously I've been running tests using ReSharper and it was able to run them without issues.